### PR TITLE
Fix serious bug

### DIFF
--- a/lib/koine/event_sourcing/aggregate_root.rb
+++ b/lib/koine/event_sourcing/aggregate_root.rb
@@ -20,6 +20,8 @@ module Koine
             events.map do |event|
               aggregate_root.send(:record_that, event)
             end
+
+            aggregate_root.send(:persist_events)
           end
         end
 
@@ -49,6 +51,10 @@ module Koine
       def increment_version
         @version ||= 0
         @version += 1
+      end
+
+      def persist_events
+        domain_events.persist_all
       end
     end
   end

--- a/spec/integration/event_sourcing_layers_spec.rb
+++ b/spec/integration/event_sourcing_layers_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe 'event sourcing layers' do
       expect(found.updated_at).to be_equal_to(aggregate.updated_at)
     end
 
+    it 'finds retrieves with all persisted events' do
+      found = aggregates.find(aggregate.id)
+
+      expect(found.send(:domain_events)).to be_all_persisted
+    end
+
     it 'creates projections' do
       aggregate.title = 'other title'
       aggregates.save(aggregate)

--- a/spec/koine/event_sourcing/aggregate_root_repository_spec.rb
+++ b/spec/koine/event_sourcing/aggregate_root_repository_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Koine::EventSourcing::AggregateRootRepository do
 
     context 'when record exists' do
       it 'returns aggregate' do
+        aggregate_root.send(:persist_events)
         expect(found).to be_equal_to(aggregate_root)
         expect(found).not_to be(aggregate_root)
       end
@@ -92,6 +93,7 @@ RSpec.describe Koine::EventSourcing::AggregateRootRepository do
 
     context 'when record exists' do
       it 'returns aggregate' do
+        aggregate_root.send(:persist_events)
         expect(found).to be_equal_to(aggregate_root)
         expect(found).not_to be(aggregate_root)
       end

--- a/spec/koine/event_sourcing/aggregate_root_spec.rb
+++ b/spec/koine/event_sourcing/aggregate_root_spec.rb
@@ -65,13 +65,20 @@ RSpec.describe Koine::EventSourcing::AggregateRoot do
   end
 
   describe '.from_event_stream' do
-    it 'reconstructs the aggregate' do
+    before do
       aggregate.title = 'new title'
       aggregate.body = 'new body'
+    end
 
-      loaded = aggregate_type.from_event_stream(events)
+    let(:loaded) { aggregate_type.from_event_stream(events) }
 
+    it 'reconstructs the aggregate' do
+      aggregate.send(:persist_events)
       expect(loaded).to be_equal_to(aggregate)
+    end
+
+    it 'marks all the events as persisted' do
+      expect(loaded.send(:domain_events)).to be_all_persisted
     end
   end
 end


### PR DESCRIPTION
Loaded aggregates had their domain events all marked as unpersisted
causing events to be saved more then once