### PR TITLE
Fix issue with missing contact attempts

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --color
---require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,9 @@ group :test, :development do
   gem 'watir'
   gem 'watir-rack'
   gem 'webdrivers', require: false
+
   gem 'byebug'
+  gem 'rb-readline'
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ group :test do
 end
 
 group :test, :development do
+  gem 'awesome_print'
+
   # code coverage
   gem 'coveralls', '~> 0.8.22', require: false
   gem 'object_comparator', '~> 0.1.3'

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :test, :development do
   gem 'simplecov', '~> 0.16.1', require: false
 
   gem 'watir'
-  gem 'watir-rack'
+  gem 'watir-rack', require: false
   gem 'webdrivers', require: false
 
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
     airbrussh (1.3.1)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.0)
+    awesome_print (1.8.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -321,6 +322,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
+  awesome_print
   babel-transpiler
   byebug
   capistrano

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rb-readline (0.5.5)
     regexp_parser (1.2.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
@@ -344,6 +345,7 @@ DEPENDENCIES
   omniauth-facebook (~> 5.0.0)
   omniauth-google-oauth2 (~> 0.5.3)
   rake
+  rb-readline
   rspec
   rubocop (= 0.58)
   rubocop-rspec (~> 1.30)
@@ -357,4 +359,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.3
+   2.0.1

--- a/frontend/apartments/pages/list/ApartmentContainer.js
+++ b/frontend/apartments/pages/list/ApartmentContainer.js
@@ -48,7 +48,11 @@ class Apartment extends React.Component {
     });
 
     return (
-      <div className={className}>
+      <div
+        className={className}
+        data-apartment={apartment.number}
+        data-apartment-id={apartment.id}
+      >
         <Grid>
           <Row>
             <Col xs={4}>
@@ -63,6 +67,8 @@ class Apartment extends React.Component {
             </Col>
             <Col xs={2}>
               <Icon
+                data-action="options"
+                data-apartment={apartment.number}
                 color="purple"
                 type={collapsed ? "plus" : "minus"}
                 onClick={this.toggleActions}

--- a/frontend/contact-attempts/pages/new/Form.js
+++ b/frontend/contact-attempts/pages/new/Form.js
@@ -38,7 +38,7 @@ export default function Form(props) {
       </PageBlock>
       <PageBlock visible={currentUser.master}>
         <Label>Data e hora no formato 2019/12/31 18:32</Label>
-        <DateTimeInput onChange={dateTimeChangeListener} />
+        <DateTimeInput name="when" onChange={dateTimeChangeListener} />
         <small>Deixe em branco para usar a data e hora atual</small>
       </PageBlock>
       <PageBlock>

--- a/frontend/shared/components/ContactAttempt.js
+++ b/frontend/shared/components/ContactAttempt.js
@@ -34,9 +34,15 @@ export default function ContactAttempt(props) {
 
   const color = contactAttempt.successful ? colors.green : colors.red;
 
+  console.log(contactAttempt);
   return (
     <div {...otherProps}>
-      <Icon type={type} color={color}>
+      <Icon
+        type={type}
+        data-contact-attempt-type={contactAttempt.type}
+        data-contact-attempt-success={contactAttempt.successful}
+        color={color}
+      >
         <DateTime>{contactAttempt.time}</DateTime>
       </Icon>
     </div>

--- a/lib/predios/domain/apartments/contact_attempt.rb
+++ b/lib/predios/domain/apartments/contact_attempt.rb
@@ -43,11 +43,11 @@ module Apartments
         time.hour,
         time.min
       )
-      self.class.new(outcome: outcome, time: time_without_precision)
+      self.class.new(outcome: outcome, time: time_without_precision, type: type)
     end
 
     def ==(other)
-      other.outcome == outcome && other.time == time
+      other.outcome == outcome && other.time == time && other.type == type
     end
   end
 end

--- a/lib/predios/domain/apartments/contact_attempts.rb
+++ b/lib/predios/domain/apartments/contact_attempts.rb
@@ -6,10 +6,8 @@ module Apartments
 
     def initialize(attempts)
       @attempts = []
-      attempts.sort_by(&:time).each do |attempt|
-        unless include?(attempt)
-          @attempts << attempt
-        end
+      attempts.each do |attempt|
+        add(attempt)
       end
     end
 
@@ -21,7 +19,13 @@ module Apartments
       @attempts.dup.pop
     end
 
-    private
+    def add(attempt)
+      unless include?(attempt)
+        @attempts << attempt
+      end
+
+      @attempts = @attempts.sort_by(&:time)
+    end
 
     def include?(attempt)
       map(&:without_precision).include?(attempt.without_precision)

--- a/spec/acceptance/contact_attempt_management_spec.rb
+++ b/spec/acceptance/contact_attempt_management_spec.rb
@@ -4,11 +4,16 @@ require 'acceptance_helper'
 
 RSpec.describe 'contact attempt management', type: :acceptance do
   let(:building) { building_factory.create(number_of_apartments: 2) }
-  let(:apartment1) { apartment_factory.create(building: building) }
-  let(:apartment2) { apartment_factory.create(building: building) }
+  let(:apartment1) do
+    apartment_factory.create_with_aggregate(building_id: building.uuid)
+  end
+  let(:apartment2) do
+    apartment_factory.create_with_aggregate(building_id: building.uuid)
+  end
 
   before do
     clear_all
+
     login_as_master
     apartment1
     apartment2
@@ -19,14 +24,11 @@ RSpec.describe 'contact attempt management', type: :acceptance do
 
     click_element(tag_name: 'span', data_apartment: apartment1.number)
     click_on('Tentar contato')
-    byebug
-    click_label('Telefone')
-    click_button(/Sim/)
-    # byebug
+    click_button('Sim')
 
-    # # default intercom
+    # default intercom
     page.wait_until do
-      page.has_element?(
+      expect(page).to have_element(
         tag_name: 'span',
         data_contact_attempt_success: 'true',
         data_contact_attempt_type: 'intercom',

--- a/spec/acceptance/contact_attempt_management_spec.rb
+++ b/spec/acceptance/contact_attempt_management_spec.rb
@@ -4,10 +4,7 @@ require 'acceptance_helper'
 
 RSpec.describe 'contact attempt management', type: :acceptance do
   let(:building) { building_factory.create(number_of_apartments: 2) }
-  let(:apartment1) do
-    apartment_factory.create_with_aggregate(building_id: building.uuid)
-  end
-  let(:apartment2) do
+  let(:apartment) do
     apartment_factory.create_with_aggregate(building_id: building.uuid)
   end
 
@@ -15,24 +12,73 @@ RSpec.describe 'contact attempt management', type: :acceptance do
     clear_all
 
     login_as_master
-    apartment1
-    apartment2
+    apartment
   end
 
   specify 'adding a contact attempt' do
     visit("/buildings/#{building.number}/apartments")
 
-    click_element(tag_name: 'span', data_apartment: apartment1.number)
+    # default with custom date
+    click_element(tag_name: 'span', data_apartment: apartment.number)
+    click_on('Tentar contato')
+    fill_in('when', with: '2019/12/31 18:32')
+    click_button('Sim')
+
+    expect(page).to have_element(
+      tag_name: 'span',
+      data_contact_attempt_success: 'true',
+      data_contact_attempt_type: 'intercom',
+      text: '31/12/2019 18:32'
+    )
+
+    # default intercom
+    click_element(tag_name: 'span', data_apartment: apartment.number)
     click_on('Tentar contato')
     click_button('Sim')
 
-    # default intercom
+    expect(page).to have_element(
+      tag_name: 'span',
+      data_contact_attempt_success: 'true',
+      data_contact_attempt_type: 'intercom'
+    )
+
+    # intercom false
+    click_element(tag_name: 'span', data_apartment: apartment.number)
+    click_on('Tentar contato')
+    click_label('Interfone')
+    click_button('Não')
+
+    expand_entries
+
+    expect(page).to have_element(
+      tag_name: 'span',
+      data_contact_attempt_success: 'false',
+      data_contact_attempt_type: 'intercom'
+    )
+
+    expand_entries
+
+    # letter true
+    click_element(tag_name: 'span', data_apartment: apartment.number)
+    click_on('Tentar contato')
+    click_label('Carta')
+    # when byebug is opened here it works
+    click_button('Sim')
+
+    expand_entries
+
+    expect(page).to have_element(
+      tag_name: 'span',
+      data_contact_attempt_success: 'true',
+      data_contact_attempt_type: 'letter'
+    )
+  end
+
+  def expand_entries
     page.wait_until do
-      expect(page).to have_element(
-        tag_name: 'span',
-        data_contact_attempt_success: 'true',
-        data_contact_attempt_type: 'intercom',
-      )
+      page.has_element?(tag_name: 'span', data_apartment: apartment.number)
     end
+
+    click_element(tag_name: 'span', text: /#{Date.today.year}/)
   end
 end

--- a/spec/acceptance/contact_attempt_management_spec.rb
+++ b/spec/acceptance/contact_attempt_management_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe 'contact attempt management', type: :acceptance do
     click_element(tag_name: 'span', data_apartment: apartment.number)
     click_on('Tentar contato')
     click_label('Carta')
-    # when byebug is opened here it works
     click_button('Sim')
 
     expand_entries

--- a/spec/acceptance/contact_attempt_management_spec.rb
+++ b/spec/acceptance/contact_attempt_management_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'acceptance_helper'
+
+RSpec.describe 'contact attempt management', type: :acceptance do
+  let(:building) { building_factory.create(number_of_apartments: 2) }
+  let(:apartment1) { apartment_factory.create(building: building) }
+  let(:apartment2) { apartment_factory.create(building: building) }
+
+  before do
+    clear_all
+    login_as_master
+    apartment1
+    apartment2
+  end
+
+  specify 'adding a contact attempt' do
+    visit("/buildings/#{building.number}/apartments")
+
+    click_element(tag_name: 'span', data_apartment: apartment1.number)
+    click_on('Tentar contato')
+    byebug
+    click_label('Telefone')
+    click_button(/Sim/)
+    # byebug
+
+    # # default intercom
+    page.wait_until do
+      page.has_element?(
+        tag_name: 'span',
+        data_contact_attempt_success: 'true',
+        data_contact_attempt_type: 'intercom',
+      )
+    end
+  end
+end

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -3,7 +3,10 @@
 require_relative './spec_helper'
 require 'webdrivers'
 
-Watir::Rack.test_app = Hanami.app
+unless ENV['WATIR_SKIP_RACK']
+  require 'watir/rack'
+  Watir::Rack.test_app = Hanami.app
+end
 
 # Chrome
 Webdrivers::Chromedriver.required_version = '72.0.3626.7'

--- a/spec/predios/domain/apartments/contact_attempts_spec.rb
+++ b/spec/predios/domain/apartments/contact_attempts_spec.rb
@@ -25,39 +25,35 @@ RSpec.describe Apartments::ContactAttempts do
       time: Time.parse('2001-02-03 04:05:06')
     )
     end
-    let(:second) do
-      Apartments::ContactAttempt.new(
-      outcome: 'contacted',
-      time: Time.parse('2001-02-03 04:05:07'),
-      type: 'letter'
-    )
-    end
-    let(:duplicate1) do
+    let(:first_duplicate) do
       Apartments::ContactAttempt.new(
       outcome: 'contacted',
       time: Time.parse('2001-02-03 04:05:09')
     )
     end
-    let(:last) do
+    let(:second) do
       Apartments::ContactAttempt.new(
-      outcome: 'failed',
-      time: Time.parse('2001-02-03 04:05:08')
+      outcome: 'contacted',
+      time: Time.parse('2001-02-03 04:05:17'),
+      type: 'letter'
     )
     end
-    let(:duplicate2) do
+    let(:third) do
       Apartments::ContactAttempt.new(
       outcome: 'failed',
-      time: Time.parse('2001-02-03 04:05:08')
+      time: Time.parse('2001-02-03 04:06:08')
     )
     end
-    let(:attempts) { described_class.new([first, second, duplicate1, duplicate2, last]) }
+    let(:third_duplicate) do
+      Apartments::ContactAttempt.new(
+      outcome: 'failed',
+      time: Time.parse('2001-02-03 04:06:02')
+    )
+    end
+    let(:attempts) { described_class.new([second, first, first_duplicate, third, third_duplicate]) }
 
     it 'removes duplicates' do
-      expect(attempts.to_a.size).to eq(3)
-      expect(attempts.to_a[0]).to eq(first)
-      expect(attempts.to_a[1]).to eq(second)
-      expect(attempts.to_a[2]).to eq(last)
-      expect(attempts.to_a).to eq([first, second, last])
+      expect(attempts.to_a).to eq([first, second, third])
     end
   end
 

--- a/spec/predios/domain/apartments/contact_attempts_spec.rb
+++ b/spec/predios/domain/apartments/contact_attempts_spec.rb
@@ -25,28 +25,39 @@ RSpec.describe Apartments::ContactAttempts do
       time: Time.parse('2001-02-03 04:05:06')
     )
     end
+    let(:second) do
+      Apartments::ContactAttempt.new(
+      outcome: 'contacted',
+      time: Time.parse('2001-02-03 04:05:07'),
+      type: 'letter'
+    )
+    end
     let(:duplicate1) do
       Apartments::ContactAttempt.new(
       outcome: 'contacted',
-      time: Time.parse('2001-02-03 04:05:07')
+      time: Time.parse('2001-02-03 04:05:09')
     )
     end
     let(:last) do
       Apartments::ContactAttempt.new(
       outcome: 'failed',
-      time: Time.parse('2001-02-03 04:05:06')
+      time: Time.parse('2001-02-03 04:05:08')
     )
     end
     let(:duplicate2) do
       Apartments::ContactAttempt.new(
       outcome: 'failed',
-      time: Time.parse('2001-02-03 04:05:07')
+      time: Time.parse('2001-02-03 04:05:08')
     )
     end
-    let(:attempts) { described_class.new([first, duplicate1, duplicate2, last]) }
+    let(:attempts) { described_class.new([first, second, duplicate1, duplicate2, last]) }
 
     it 'removes duplicates' do
-      expect(attempts.to_a).to eq([first, last])
+      expect(attempts.to_a.size).to eq(3)
+      expect(attempts.to_a[0]).to eq(first)
+      expect(attempts.to_a[1]).to eq(second)
+      expect(attempts.to_a[2]).to eq(last)
+      expect(attempts.to_a).to eq([first, second, last])
     end
   end
 

--- a/spec/support/acceptance_spec_helpers.rb
+++ b/spec/support/acceptance_spec_helpers.rb
@@ -18,6 +18,10 @@ module AcceptanceSpecHelpers
   end
 
   def visit(path)
+    if ENV['WATIR_SKIP_RACK']
+      path = "http://localhost:4000#{path}"
+    end
+
     browser.goto(path)
   end
 
@@ -64,6 +68,10 @@ module AcceptanceSpecHelpers
 
   def click_on(text)
     browser.element(text: text).click
+  end
+
+  def click_element(*options)
+    browser.element(*options).click
   end
 
   def click_button(text)

--- a/spec/support/acceptance_spec_helpers.rb
+++ b/spec/support/acceptance_spec_helpers.rb
@@ -74,6 +74,10 @@ module AcceptanceSpecHelpers
     browser.element(*options).click
   end
 
+  def click_label(text)
+    browser.label(text: text).click
+  end
+
   def click_button(text)
     browser.button(text: text).click
   end

--- a/spec/support/factories/apartment_projection_factory.rb
+++ b/spec/support/factories/apartment_projection_factory.rb
@@ -13,6 +13,7 @@ class ApartmentProjectionFactory < EntityFactory
     super(attributes)
   end
 
+  # TODO: Move it somewhere else. Maybe it deserves a factory of its own
   def create_with_aggregate(attributes = {})
     attributes = sample_attributes.merge(attributes)
     command = Apartments::Commands::CreateApartment.new(attributes)


### PR DESCRIPTION
Some contact attempts were not being saved because they matched same time and outcome, but not type. New acceptance tests revealed this problem.